### PR TITLE
Fix external dataproviders when psalm runs on a single file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - composer clear-cache
 
 install:
-  - composer install
+  - travis_retry composer install
   - if [[ "$DEPS" = 'high' || "$DEPS" = 'dev' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS update; fi
   - if [[ "$DEPS" = 'high' ]]; then composer require $DEFAULT_COMPOSER_FLAGS --prefer-stable --update-with-dependencies vimeo/psalm; fi
   - if [[ "$DEPS" = 'low' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-lowest --prefer-stable update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install:
   - composer install
   - if [[ "$DEPS" = 'high' || "$DEPS" = 'dev' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS update; fi
-  - if [[ "$DEPS" = 'high' ]]; then composer require $DEFAULT_COMPOSER_FLAGS --prefer-stable vimeo/psalm; fi
+  - if [[ "$DEPS" = 'high' ]]; then composer require $DEFAULT_COMPOSER_FLAGS --prefer-stable --update-with-dependencies vimeo/psalm; fi
   - if [[ "$DEPS" = 'low' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-lowest --prefer-stable update; fi
   - if [[ "$DEPS" = 'stable' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-stable update; fi
   - ./vendor/bin/psalm --version

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3.1",
         "codeception/base": "^2.5",
-        "weirdan/codeception-psalm-module": "^0.2.2"
+        "weirdan/codeception-psalm-module": "^0.4.0"
     },
     "extra": {
         "psalm": {

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -197,7 +197,7 @@ class TestCaseHandler implements
                 $provider_method_exists = $codebase->methodExists(
                     (string) $provider_method_id,
                     $provider_docblock_location,
-                    $declaring_method_id
+                    (string) $declaring_method_id
                 );
 
                 if (!$provider_method_exists) {

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -150,7 +150,7 @@ class TestCaseHandler implements
             }
 
             $codebase->methodExists(
-                $declaring_method_id,
+                (string) $declaring_method_id,
                 null,
                 'PHPUnit\Framework\TestSuite::run'
             );
@@ -195,7 +195,7 @@ class TestCaseHandler implements
 
                 // methodExists also can mark methods as used (weird, but handy)
                 $provider_method_exists = $codebase->methodExists(
-                    $provider_method_id,
+                    (string) $provider_method_id,
                     $provider_docblock_location,
                     $declaring_method_id
                 );

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -413,15 +413,17 @@ class TestCaseHandler implements
         }
     }
 
-    /** @return Type\Atomic[] */
+    /** @return non-empty-array<string,Type\Atomic> */
     private static function getAtomics(Type\Union $union): array
     {
         if (method_exists($union, 'getAtomicTypes')) {
-            /** @var Type\Atomic[] annotated for versions missing the method */
+            /** @var non-empty-array<string, Type\Atomic> annotated for versions missing the method */
             return $union->getAtomicTypes();
         } else {
             /** @psalm-suppress DeprecatedMethod annotated for newer versions that deprecated the method */
-            return $union->getTypes();
+            $types = $union->getTypes();
+            assert(!empty($types));
+            return $types;
         }
     }
 
@@ -452,13 +454,6 @@ class TestCaseHandler implements
             } else {
                 throw new \RuntimeException('unexpected type');
             }
-        }
-
-        if (empty($key_types) || empty($value_types)) {
-            return new Type\Atomic\TIterable([
-                Type::getMixed(),
-                Type::getMixed(),
-            ]);
         }
 
         $combine =

--- a/tests/acceptance/Assert75.feature
+++ b/tests/acceptance/Assert75.feature
@@ -127,24 +127,17 @@ Feature: Assert (PHPUnit 7.5+)
   Scenario: Assert::assertIsScalar()
     Given I have the following code
       """
-      /** @psalm-suppress MixedAssignment */
-      $s = mixed();
+      /** @return scalar */
+      function f() {
+        /** @psalm-suppress MixedAssignment */
+        $s = mixed();
 
-      Assert::assertIsScalar($s); // int|string|float|bool
-      // all of the following should cause errors
-      if (is_array($s)) {}
-      if (is_resource($s)) {}
-      if (is_object($s)) {}
-      if (is_null($s)) {}
+        Assert::assertIsScalar($s);
+        return $s;
+      }
       """
     When I run Psalm
-    Then I see these errors
-      | Type                      | Message                                                                                                               |
-      | DocblockTypeContradiction | Found a contradiction with a docblock-defined type when evaluating $s and trying to reconcile type 'scalar' to array  |
-      | DocblockTypeContradiction | Cannot resolve types for $s - docblock-defined type scalar does not contain resource                                  |
-      | DocblockTypeContradiction | Found a contradiction with a docblock-defined type when evaluating $s and trying to reconcile type 'scalar' to object |
-      | DocblockTypeContradiction | Cannot resolve types for $s - docblock-defined type scalar does not contain null                                      |
-    And I see no other errors
+    Then I see no errors
 
   Scenario: Assert::assertIsCallable()
     Given I have the following code


### PR DESCRIPTION
This fixes false-positive UndefinedClass issues for external data providers when Psalm is run on a single test file with cold cache.

Fixes psalm/psalm-plugin-phpunit#57