### PR TITLE
Cache effectively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
     - 7.4
 before_install:
     - phpenv config-rm xdebug.ini || true
-    - composer clear-cache
 
 install:
   - travis_retry composer install
@@ -29,7 +28,8 @@ env:
 
 cache:
   directories:
-    - ./vendor
+    - $HOME/.composer/cache/files
+    - $HOME/.composer/cache/vcs
 
 allow_failures:
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
         - DEPS="dev"
     global:
         - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-suggest"
-
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - phpenv config-rm xdebug.ini || true
 
 install:
+  - composer config --global discard-changes true
   - travis_retry composer install
   - if [[ "$DEPS" = 'high' || "$DEPS" = 'dev' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS update; fi
   - if [[ "$DEPS" = 'high' ]]; then composer require $DEFAULT_COMPOSER_FLAGS --prefer-stable --update-with-dependencies vimeo/psalm; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
         - DEPS="dev"
     global:
         - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-suggest"
+
 cache:
   directories:
     - $HOME/.composer/cache/files


### PR DESCRIPTION
Instead of caching the vendor folder (which changes for every job, as different levels of dependencies are installed) we now cache composer cache folders (where it stores downloaded packages and cloned repos).

This should make caching much more effective, without introducing any persistent issues (as metadata used for dependency resolution is not cached).

Note that caches won't be available on the first build. I'll add a test commit once the initial build completes.
