### PR TITLE
Ensure compatibility with PhpStorm

### DIFF
--- a/stubs/TestCase.php
+++ b/stubs/TestCase.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use Prophecy\Prophecy\ObjectProphecy;
 
-abstract class TestCase extends Assert implements Test, SelfDescribing
+abstract class TestCase extends Assert
 {
     /**
      * @template T


### PR DESCRIPTION
Since `TestCase` stub just adds corresponding PhpDoc blocks there is no need to clarify again what interfaces it implements. It has been already defined in the [origin](https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L59) class.

By this I fix compatibility with PhpStorm that complains on any test implementation inherited from `\PHPUnit\Framework\TestCase`:

```
Class must be declared abstract or implement methods 'run', 'count', 'toString'
```