### PR TITLE
Update tests to account for tuples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "codeception/codeception": "^4.0.3",
         "squizlabs/php_codesniffer": "^3.3.1",
-        "weirdan/codeception-psalm-module": "^0.4.0"
+        "weirdan/codeception-psalm-module": "^0.7.1"
     },
     "extra": {
         "psalm": {

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -421,8 +421,8 @@ Feature: TestCase
       """
     When I run Psalm
     Then I see these errors
-      | Type            | Message                                                                                                                                  |
-      | InvalidArgument | Argument 1 of NS\MyTestCase::testSomething expects int, string provided by NS\MyTestCase::provide():(iterable<string, array{0: string}>) |
+      | Type            | Message                                                                                                                                               |
+      | InvalidArgument | /Argument 1 of NS\\MyTestCase::testSomething expects int, string provided by NS\\MyTestCase::provide\(\):\(iterable<string, array\{(0: )?string\}>\)/ |
     And I see no other errors
 
   Scenario: Invalid dataset array is reported
@@ -469,8 +469,8 @@ Feature: TestCase
       """
     When I run Psalm
     Then I see these errors
-      | Type            | Message                                                                                                                                                     |
-      | TooFewArguments | Too few arguments for NS\MyTestCase::testSomething - expecting at least 2, but saw 1 provided by NS\MyTestCase::provide():(iterable<string, array{0: int}>) |
+      | Type            | Message                                                                                                                                                                  |
+      | TooFewArguments | /Too few arguments for NS\\MyTestCase::testSomething - expecting at least 2, but saw 1 provided by NS\\MyTestCase::provide\(\):\(iterable<string, array\{(0: )?int\}>\)/ |
     And I see no other errors
 
   Scenario: Referenced providers are not marked as unused
@@ -960,8 +960,8 @@ Feature: TestCase
       """
     When I run Psalm
     Then I see these errors
-      | Type            | Message                                                                                                                                                     |
-      | TooFewArguments | Too few arguments for NS\MyTestCase::testSomething - expecting at least 2, but saw 1 provided by NS\MyTestCase::provide():(iterable<string, array{0: int}>) |
+      | Type            | Message                                                                                                                                                                  |
+      | TooFewArguments | /Too few arguments for NS\\MyTestCase::testSomething - expecting at least 2, but saw 1 provided by NS\\MyTestCase::provide\(\):\(iterable<string, array\{(0: )?int\}>\)/ |
     And I see no other errors
 
   Scenario: Providers generating incompatible datasets for variadic tests are reported


### PR DESCRIPTION
This fixes test failures on recent psalm versions.