### PR TITLE
Fix Prophecy-related issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "codeception/codeception": "^4.0.3",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "squizlabs/php_codesniffer": "^3.3.1",
-        "weirdan/codeception-psalm-module": "^0.7.1"
+        "weirdan/codeception-psalm-module": "^0.7.1",
+        "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "extra": {
         "psalm": {

--- a/stubs/Prophecy.phpstub
+++ b/stubs/Prophecy.phpstub
@@ -24,3 +24,16 @@ namespace Prophecy {
         public static function allOf(...$tokens): Token\LogicalAndToken {}
     }
 }
+
+namespace Prophecy\PhpUnit {
+    use Prophecy\Prophecy\ObjectProphecy;
+    trait ProphecyTrait
+    {
+        /**
+         * @template T
+         * @param class-string<T> $classOrInterface
+         * @return ObjectProphecy<T>
+         */
+        protected function prophesize($classOrInterface): ObjectProphecy {}
+    }
+}

--- a/stubs/TestCase.phpstub
+++ b/stubs/TestCase.phpstub
@@ -47,7 +47,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * @param class-string<T> $classOrInterface
      * @return ObjectProphecy<T>
      */
-    public function prophesize($classOrInterface): ObjectProphecy {}
+    protected function prophesize($classOrInterface): ObjectProphecy {}
 
     /**
      * @param class-string<\Throwable> $exception

--- a/tests/acceptance/Prophecy.feature
+++ b/tests/acceptance/Prophecy.feature
@@ -89,4 +89,22 @@ Feature: Prophecy
       """
     When I run Psalm
     Then I see these errors
+      | Type                  | Message                                                                                                 |
       | InvalidScalarArgument | Argument 1 of Prophecy\Argument::that expects callable(mixed...):bool, Closure():string(hello) provided |
+    And I see no other errors
+
+  Scenario: prophesize() provided by ProphecyTrait is generic
+    Given I have the following code
+      """
+      use Prophecy\PhpUnit\ProphecyTrait;
+      class SUT { public function getString(): string { return "zzz"; } }
+      class MyTestCase extends TestCase
+      {
+        use ProphecyTrait;
+        public function testSomething(): void {
+          $this->prophesize(SUT::class)->reveal()->getString();
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
1. `prophesize()` has always been protected, not public
2. Provide generic definition for `prophesize()` implemented by `phpspec/prophecy-phpunit`