### PR TITLE
Move phpunit to devRequirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,15 @@
         "ext-simplexml": "*",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/package-versions-deprecated": "^1.10",
-        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
         "vimeo/psalm": "dev-master || dev-4.x || ^4.0"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<7.5"
     },
     "require-dev": {
         "php": "^7.3 || ^8.0",
         "codeception/codeception": "^4.0.3",
+        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
         "squizlabs/php_codesniffer": "^3.3.1",
         "weirdan/codeception-psalm-module": "^0.11.0",
         "weirdan/prophecy-shim": "^1.0 || ^2.0"


### PR DESCRIPTION
Related to this issue: https://github.com/psalm/psalm-plugin-phpunit/issues/89

Phpunit shouldn't be a direct dependency. There are other way to use this plugin.
A conflict if the right way to restrict the version.

It allows using `extraFiles` in order to load the phpunit dependency (for instance with the symfony phpunit-bridge) without
- downloading phpunit at the wrong version
- triggering symfony flex (if I remove this pluign, it removes phpunit and all my phpunit config).