### PR TITLE
Fix exception class in InvocationMocker und MockBuilder strub

### DIFF
--- a/stubs/InvocationMocker.phpstub
+++ b/stubs/InvocationMocker.phpstub
@@ -8,7 +8,7 @@ class InvocationMocker
      *
      * @return static
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function with(...$arguments) {}
 }

--- a/stubs/MockBuilder.phpstub
+++ b/stubs/MockBuilder.phpstub
@@ -50,7 +50,7 @@ interface MockObject
      *
      * @return InvocationMocker
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function method($constraint);
 }


### PR DESCRIPTION
After enabling `checkForThrowsDocblock` psalm crashed with 

```
Uncaught Exception: Could not get class storage for phpunit\framework\mockobject\builder\runtimeexception
```

I had a look at PHPUnit and there really isn't a `RuntimeException` in that namespaces and after browsing through some versions I think there never has been. So I guess what's really meant is the global one.