### PR TITLE
Remove dead code

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="phpunit-psalm-plugin">
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+    name="phpunit-psalm-plugin"
+>
     <!-- display progress -->
     <arg value="p"/>
     <arg name="colors"/>


### PR DESCRIPTION
The code being removed is no longer used as composer constraints have been tightened to not include those older versions that required workarounds.