### PR TITLE
Improve provider non-optional argument phrasing

### DIFF
--- a/src/Hooks/TestCaseHandler.php
+++ b/src/Hooks/TestCaseHandler.php
@@ -345,7 +345,7 @@ class TestCaseHandler implements
                     } elseif ($potential_argument_type->possibly_undefined && !$is_optional) {
                         IssueBuffer::accepts(new Issue\InvalidArgument(
                             'Argument ' . ($param_offset + 1) . ' of ' . $method_name
-                            . ' has no default value, but possibly undefined '
+                            . ' is not optional, but possibly undefined '
                             . $potential_argument_type->getId() . ' provided'
                             . ' by ' . $provider_method_id . '():(' . $provider_return_type_string . ')',
                             $provider_docblock_location


### PR DESCRIPTION
I just ran across a case where I added an argument to a test method and forgot to give it a default value, and this made all previous arguments with defaults non-optional. The phrasing here confused me because I could clearly see that the argument it was complaining about had a default value, and it took me a while to find the actual issue that I forgot to add a default value to the new argument.