### PR TITLE
Handle new list representation

### DIFF
--- a/src/Hooks/TestCaseHandler.php
+++ b/src/Hooks/TestCaseHandler.php
@@ -472,7 +472,6 @@ class TestCaseHandler implements
         } elseif (
             // list-like keyed array
             $atomic instanceof Type\Atomic\TKeyedArray
-            && $atomic->properties === []
             && $atomic->fallback_params !== null
         ) {
             return $atomic->fallback_params[1];

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -1000,7 +1000,7 @@ Feature: TestCase
     Given I have the following code
       """
       class MyTestCase extends TestCase {
-        /** @return iterable<string,array{float,1?:string}> */
+        /** @return iterable<string,array{0:float,1?:string}> */
         public function provide() {
           yield "data set" => [1., "a"];
         }


### PR DESCRIPTION
Previously Psalm would return lists as instances of Type\Atomic\TList.
Recently it started returning TKeyedArray with fallback_params instead.
