### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
             - name: Get Composer Cache Directories
               id: composer-cache
               run: |
-                  echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-                  echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+                  echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                  echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
             - name: Retrieve cached packages
               uses: actions/cache@v2
@@ -65,8 +65,8 @@ jobs:
             - name: Get Composer Cache Directories
               id: composer-cache
               run: |
-                  echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-                  echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+                  echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                  echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
             - name: Retrieve cached packages
               uses: actions/cache@v2
@@ -111,8 +111,8 @@ jobs:
             - name: Get Composer Cache Directories
               id: composer-cache
               run: |
-                  echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-                  echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+                  echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                  echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
             - name: Retrieve cached packages
               uses: actions/cache@v2


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/