### PR TITLE
Make param explicitly nullable

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,7 +10,7 @@ use Psalm\Plugin\RegistrationInterface;
 class Plugin implements PluginEntryPointInterface
 {
     /** @return void */
-    public function __invoke(RegistrationInterface $psalm, SimpleXMLElement $config = null): void
+    public function __invoke(RegistrationInterface $psalm, SimpleXMLElement|null $config = null): void
     {
         if (VersionUtils::packageVersionIs('phpunit/phpunit', '<', '8.0')) {
             $psalm->addStubFile(__DIR__ . '/../stubs/Assert_75.phpstub');


### PR DESCRIPTION
> Deprecated: Psalm\PhpUnitPlugin\Plugin::__invoke(): Implicitly marking parameter $config as nullable is deprecated, the explicit nullable type must be used instead in F:\projects\phpmyadmin\vendor\psalm\plugin-phpunit\src\Plugin.php on line 13