### PR TITLE
Ensure that all `@dataProvider` and `#[DataProvider]` (multiple) are considered

### DIFF
--- a/src/Hooks/TestCaseHandler.php
+++ b/src/Hooks/TestCaseHandler.php
@@ -566,19 +566,19 @@ final class TestCaseHandler implements
                 $aliases,
             ),
         );
-        $matchingAttributes = array_merge(...array_map(
+        $matchingAttributes = array_merge(...array_values(array_map(
             $attributesInGroupMatchingRequestedAttributeName,
             $method->getAttrGroups(),
-        ));
+        )));
 
         if ($matchingAttributes === []) {
             return null;
         }
 
-        return array_merge(...array_map(
+        return array_merge(...array_values(array_map(
             $onlyStringLiteralExpressions,
             $matchingAttributes,
-        ));
+        )));
     }
 
     /** @return array<string, array<int,string>> */

--- a/src/Hooks/TestCaseHandler.php
+++ b/src/Hooks/TestCaseHandler.php
@@ -566,14 +566,19 @@ final class TestCaseHandler implements
                 $aliases,
             ),
         );
+        $matchingAttributes = array_merge(...array_map(
+            $attributesInGroupMatchingRequestedAttributeName,
+            $method->getAttrGroups(),
+        ));
 
-        foreach ($method->getAttrGroups() as $group) {
-            foreach ($attributesInGroupMatchingRequestedAttributeName($group) as $attribute) {
-                return $onlyStringLiteralExpressions($attribute);
-            }
+        if ($matchingAttributes === []) {
+            return null;
         }
 
-        return null;
+        return array_merge(...array_map(
+            $onlyStringLiteralExpressions,
+            $matchingAttributes,
+        ));
     }
 
     /** @return array<string, array<int,string>> */

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -231,6 +231,62 @@ Feature: TestCase
     When I run Psalm
     Then I see no errors
 
+  Scenario: Multiple valid iterable @dataProvider are allowed, and all are used
+    Given I have the following code
+      """
+      use PHPUnit\Framework\Attributes;
+
+      final class MyTestCase extends TestCase
+      {
+        /** @return iterable<int,array<int,int>> */
+        public function provider1() {
+          yield [1];
+        }
+
+        /** @return iterable<int,array<int,int>> */
+        public function provider2() {
+          yield [1];
+        }
+
+        /**
+         * @dataProvider provider1
+         * @dataProvider provider2
+         */
+        public function testSomething(int $int): void {
+          $this->assertEquals(1, $int);
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Multiple valid iterable #[DataProvider]s are allowed, and all are used
+    Given I have the following code
+      """
+      use PHPUnit\Framework\Attributes;
+
+      final class MyTestCase extends TestCase
+      {
+        /** @return iterable<int,array<int,int>> */
+        public function provider1() {
+          yield [1];
+        }
+
+        /** @return iterable<int,array<int,int>> */
+        public function provider2() {
+          yield [1];
+        }
+
+        #[Attributes\DataProvider('provider1')]
+        #[Attributes\DataProvider('provider2')]
+        public function testSomething(int $int): void {
+          $this->assertEquals(1, $int);
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
   Scenario: Invalid generator data provider is reported
     Given I have the following code
       """


### PR DESCRIPTION
Ref: https://github.com/psalm/psalm-plugin-phpunit/pull/149#issuecomment-2766891341
Ref: https://github.com/theodorejb/saml-utils/blob/2392b576799dd76957799e82dcb6df9e089e76bc/tests/DataProviderTest.php

/cc @theodorejb